### PR TITLE
Pin python version in CI to avoid dask error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: True
       matrix:
-        python-version: [3.8, "3.11"]
+        python-version: [3.8, "3.11.8"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
Due to https://github.com/dask/dask/issues/11038 we need to pin python to 3.8.11 in CI.